### PR TITLE
Add MySQL Provider

### DIFF
--- a/AspNet5MultipleProject.sln
+++ b/AspNet5MultipleProject.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{473E7822-72A4-4268-BEE5-17807D09B880}"
 EndProject
@@ -21,6 +21,8 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "DataAccessMsSqlServerProvider", "src\DataAccessMsSqlServerProvider\DataAccessMsSqlServerProvider.xproj", "{37337A23-6C0A-405D-8239-D72D192BD6D2}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "DataAccessPostgreSqlProvider", "src\DataAccessPostgreSqlProvider\DataAccessPostgreSqlProvider.xproj", "{A336B1FE-BD9E-4938-9E46-A5D778245488}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "DataAccessMySqlProvider", "src\DataAccessMySqlProvider\DataAccessMySqlProvider.xproj", "{72341334-B38F-42F4-845B-2BD006BD09CB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -48,6 +50,10 @@ Global
 		{A336B1FE-BD9E-4938-9E46-A5D778245488}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A336B1FE-BD9E-4938-9E46-A5D778245488}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A336B1FE-BD9E-4938-9E46-A5D778245488}.Release|Any CPU.Build.0 = Release|Any CPU
+		{72341334-B38F-42F4-845B-2BD006BD09CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{72341334-B38F-42F4-845B-2BD006BD09CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{72341334-B38F-42F4-845B-2BD006BD09CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{72341334-B38F-42F4-845B-2BD006BD09CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -58,5 +64,6 @@ Global
 		{C621779A-DC48-4322-AAC9-A813A7002A42} = {473E7822-72A4-4268-BEE5-17807D09B880}
 		{37337A23-6C0A-405D-8239-D72D192BD6D2} = {473E7822-72A4-4268-BEE5-17807D09B880}
 		{A336B1FE-BD9E-4938-9E46-A5D778245488} = {473E7822-72A4-4268-BEE5-17807D09B880}
+		{72341334-B38F-42F4-845B-2BD006BD09CB} = {473E7822-72A4-4268-BEE5-17807D09B880}
 	EndGlobalSection
 EndGlobal

--- a/src/AspNet5MultipleProject/Startup.cs
+++ b/src/AspNet5MultipleProject/Startup.cs
@@ -5,6 +5,8 @@ using Newtonsoft.Json;
 using DataAccessMsSqlServerProvider;
 using DataAccessPostgreSqlProvider;
 using DataAccessSqliteProvider;
+using DataAccessMySqlProvider;
+using MySQL.Data.Entity.Extensions;
 using DomainModel;
 using System.IO;
 using Microsoft.AspNetCore.Builder;
@@ -55,17 +57,29 @@ namespace AspNet5MultipleProject
 
             //services.AddScoped<IDataAccessProvider, DataAccessMsSqlServerProvider.DataAccessMsSqlServerProvider>();
 
-            // Use a PostgreSQL database
-            var sqlConnectionString = Configuration["DataAccessPostgreSqlProvider:ConnectionString"];
+            //Use a PostgreSQL database
+            //var sqlConnectionString = Configuration["DataAccessPostgreSqlProvider:ConnectionString"];
 
-            services.AddDbContext<DomainModelPostgreSqlContext>(options =>
-                options.UseNpgsql(
+            //services.AddDbContext<DomainModelPostgreSqlContext>(options =>
+            //    options.UseNpgsql(
+            //        sqlConnectionString,
+            //        b => b.MigrationsAssembly("AspNet5MultipleProject")
+            //    )
+            //);
+
+            //services.AddScoped<IDataAccessProvider, DataAccessPostgreSqlProvider.DataAccessPostgreSqlProvider>();
+
+            //Use a MySQL database
+            var sqlConnectionString = Configuration["DataAccessMySqlProvider:ConnectionString"];
+
+            services.AddDbContext<DomainModelMySqlContext>(options =>
+                options.UseMySQL(
                     sqlConnectionString,
                     b => b.MigrationsAssembly("AspNet5MultipleProject")
                 )
             );
-
-            services.AddScoped<IDataAccessProvider, DataAccessPostgreSqlProvider.DataAccessPostgreSqlProvider>();
+            
+            services.AddScoped<IDataAccessProvider, DataAccessMySqlProvider.DataAccessMySqlProvider>();
 
             //var serializerSettings = new JsonSerializerSettings
             //{

--- a/src/AspNet5MultipleProject/config.json
+++ b/src/AspNet5MultipleProject/config.json
@@ -1,11 +1,14 @@
 ﻿{
-    "DataAccessSqliteProvider": {
-        "ConnectionString": "Data Source=C:\\git\\damienbod\\AspNet5MultipleProject\\src\\DataAccessSqliteProvider\\dataeventrecords.sqlite"
-    },
-    "DataAccessMsSqlServerProvider": {
-        "ConnectionString": "Data Source=N275\\MSSQLSERVER2014;Initial Catalog=WebApiFileTable;Integrated Security=True;"
-    },
-    "DataAccessPostgreSqlProvider": {
-        "ConnectionString": "User ID=damienbod;Password=1234;Host=localhost;Port=5432;Database=damienbod;Pooling=true;"
-    }
+  "DataAccessSqliteProvider": {
+    "ConnectionString": "Data Source=C:\\git\\damienbod\\AspNet5MultipleProject\\src\\DataAccessSqliteProvider\\dataeventrecords.sqlite"
+  },
+  "DataAccessMsSqlServerProvider": {
+    "ConnectionString": "Data Source=N275\\MSSQLSERVER2014;Initial Catalog=WebApiFileTable;Integrated Security=True;"
+  },
+  "DataAccessPostgreSqlProvider": {
+    "ConnectionString": "User ID=damienbod;Password=1234;Host=localhost;Port=5432;Database=damienbod;Pooling=true;"
+  },
+  "DataAccessMySqlProvider": {
+    "ConnectionString": "server=localhost;userid=damienbod;password=1234;database=damienbod;"
+  }
 }

--- a/src/AspNet5MultipleProject/project.json
+++ b/src/AspNet5MultipleProject/project.json
@@ -1,51 +1,52 @@
 ﻿{
-    "dependencies": {
-        "Microsoft.NETCore.App": {
-            "version": "1.0.0",
-            "type": "platform"
-        },
-        "DomainModel": "*",
-        "DataAccessSqliteProvider": "1.0.0",
-        "DataAccessMsSqlServerProvider": "1.0.0",
-        "DataAccessPostgreSqlProvider": "1.0.0",
-        "Microsoft.EntityFrameworkCore.Tools": {
-            "version": "1.0.0-preview2-final",
-            "imports": [
-                "portable-net45+win8+dnxcore50",
-                "portable-net45+win8"
-            ]
-        },
-        "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
-        "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-        "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0",
-        "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0",
-        "Microsoft.AspNetCore.Mvc": "1.0.0",
-        "Microsoft.AspNetCore.Razor.Tools": {
-            "version": "1.0.0-preview2-final",
-            "type": "build"
-        },
-        "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-        "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
-        "Microsoft.AspNetCore.StaticFiles": "1.0.0",
-        "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
-        "Microsoft.Extensions.Configuration.Json": "1.0.0",
-        "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0",
-        "Microsoft.Extensions.PlatformAbstractions": "1.0.0",
-        "Microsoft.Extensions.DependencyModel": "1.0.0",
-        "Microsoft.Extensions.Logging": "1.0.0",
-        "Microsoft.Extensions.Logging.Console": "1.0.0",
-        "Microsoft.Extensions.Logging.Debug": "1.0.0",
-        "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0",
-        "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
-            "version": "1.0.0-preview2-final",
-            "type": "build"
-        },
-        "Microsoft.VisualStudio.Web.CodeGenerators.Mvc": {
-            "version": "1.0.0-preview2-final",
-            "type": "build"
-        },
-        "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0"
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "version": "1.0.0",
+      "type": "platform"
     },
+    "DomainModel": "*",
+    "DataAccessSqliteProvider": "1.0.0",
+    "DataAccessMsSqlServerProvider": "1.0.0",
+    "DataAccessPostgreSqlProvider": "1.0.0",
+    "DataAccessMySqlProvider": "1.0.0",
+    "Microsoft.EntityFrameworkCore.Tools": {
+      "version": "1.0.0-preview2-final",
+      "imports": [
+        "portable-net45+win8+dnxcore50",
+        "portable-net45+win8"
+      ]
+    },
+    "Microsoft.AspNetCore.Authentication.Cookies": "1.0.0",
+    "Microsoft.AspNetCore.Diagnostics": "1.0.0",
+    "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore": "1.0.0",
+    "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "1.0.0",
+    "Microsoft.AspNetCore.Mvc": "1.0.0",
+    "Microsoft.AspNetCore.Razor.Tools": {
+      "version": "1.0.0-preview2-final",
+      "type": "build"
+    },
+    "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
+    "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0",
+    "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0",
+    "Microsoft.Extensions.PlatformAbstractions": "1.0.0",
+    "Microsoft.Extensions.DependencyModel": "1.0.0",
+    "Microsoft.Extensions.Logging": "1.0.0",
+    "Microsoft.Extensions.Logging.Console": "1.0.0",
+    "Microsoft.Extensions.Logging.Debug": "1.0.0",
+    "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.0.0",
+    "Microsoft.VisualStudio.Web.CodeGeneration.Tools": {
+      "version": "1.0.0-preview2-final",
+      "type": "build"
+    },
+    "Microsoft.VisualStudio.Web.CodeGenerators.Mvc": {
+      "version": "1.0.0-preview2-final",
+      "type": "build"
+    },
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.0.0"
+  },
 
   "tools": {
     "Microsoft.AspNetCore.Razor.Tools": {

--- a/src/DataAccessMySqlProvider/DataAccessMySqlProvider.cs
+++ b/src/DataAccessMySqlProvider/DataAccessMySqlProvider.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DomainModel;
+using DomainModel.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DataAccessMySqlProvider
+{
+    public class DataAccessMySqlProvider : IDataAccessProvider
+    {
+        private readonly DomainModelMySqlContext _context;
+        private readonly ILogger _logger;
+
+        public DataAccessMySqlProvider(DomainModelMySqlContext context, ILoggerFactory loggerFactory)
+        {
+            _context = context;
+            _logger = loggerFactory.CreateLogger("DataAccessMySqlProvider");
+        }
+
+        public void AddDataEventRecord(DataEventRecord dataEventRecord)
+        {
+            if (dataEventRecord.SourceInfo != null && dataEventRecord.SourceInfoId == 0)
+            {
+                _context.SourceInfos.Add(dataEventRecord.SourceInfo);
+            }
+
+            _context.DataEventRecords.Add(dataEventRecord);
+            _context.SaveChanges();
+        }
+
+        public void UpdateDataEventRecord(long dataEventRecordId, DataEventRecord dataEventRecord)
+        {
+            _context.DataEventRecords.Update(dataEventRecord);
+            _context.SaveChanges();
+        }
+
+        public void DeleteDataEventRecord(long dataEventRecordId)
+        {
+            var entity = _context.DataEventRecords.First(t => t.DataEventRecordId == dataEventRecordId);
+            _context.DataEventRecords.Remove(entity);
+            _context.SaveChanges();
+        }
+
+        public DataEventRecord GetDataEventRecord(long dataEventRecordId)
+        {
+            return _context.DataEventRecords.First(t => t.DataEventRecordId == dataEventRecordId);
+        }
+
+        public List<DataEventRecord> GetDataEventRecords()
+        {
+            // Using the shadow property EF.Property<DateTime>(dataEventRecord)
+            return _context.DataEventRecords.OrderByDescending(dataEventRecord => EF.Property<DateTime>(dataEventRecord, "UpdatedTimestamp")).ToList();
+        }
+
+        public List<SourceInfo> GetSourceInfos(bool withChildren)
+        {
+            // Using the shadow property EF.Property<DateTime>(srcInfo)
+            if (withChildren)
+            {
+                return _context.SourceInfos.Include(s => s.DataEventRecords).OrderByDescending(srcInfo => EF.Property<DateTime>(srcInfo, "UpdatedTimestamp")).ToList();
+            }
+
+            return _context.SourceInfos.OrderByDescending(srcInfo => EF.Property<DateTime>(srcInfo, "UpdatedTimestamp")).ToList();
+        }
+    }
+}

--- a/src/DataAccessMySqlProvider/DataAccessMySqlProvider.xproj
+++ b/src/DataAccessMySqlProvider/DataAccessMySqlProvider.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>72341334-b38f-42f4-845b-2bd006bd09cb</ProjectGuid>
+    <RootNamespace>DataAccessMySqlProvider</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/DataAccessMySqlProvider/DomainModelMySqlContext.cs
+++ b/src/DataAccessMySqlProvider/DomainModelMySqlContext.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq;
+using DomainModel.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+namespace DataAccessMySqlProvider
+{ 
+    // >dotnet ef migration add testMigration
+    public class DomainModelMySqlContext : DbContext
+    {
+        public DomainModelMySqlContext(DbContextOptions<DomainModelMySqlContext> options) :base(options)
+        { }
+        
+        public DbSet<DataEventRecord> DataEventRecords { get; set; }
+
+        public DbSet<SourceInfo> SourceInfos { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            builder.Entity<DataEventRecord>().HasKey(m => m.DataEventRecordId);
+            builder.Entity<SourceInfo>().HasKey(m => m.SourceInfoId);
+
+            // shadow properties
+            builder.Entity<DataEventRecord>().Property<DateTime>("UpdatedTimestamp");
+            builder.Entity<SourceInfo>().Property<DateTime>("UpdatedTimestamp");
+
+            base.OnModelCreating(builder);
+        }
+
+        public override int SaveChanges()
+        {
+            ChangeTracker.DetectChanges();
+
+            updateUpdatedProperty<SourceInfo>();
+            updateUpdatedProperty<DataEventRecord>();
+
+            return base.SaveChanges();
+        }
+
+        private void updateUpdatedProperty<T>() where T : class
+        {
+            var modifiedSourceInfo =
+                ChangeTracker.Entries<T>()
+                    .Where(e => e.State == EntityState.Added || e.State == EntityState.Modified);
+
+            foreach (var entry in modifiedSourceInfo)
+            {
+                entry.Property("UpdatedTimestamp").CurrentValue = DateTime.UtcNow;
+            }
+        }
+    }
+}

--- a/src/DataAccessMySqlProvider/Properties/AssemblyInfo.cs
+++ b/src/DataAccessMySqlProvider/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("DataAccessMySqlProvider")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("72341334-b38f-42f4-845b-2bd006bd09cb")]

--- a/src/DataAccessMySqlProvider/project.json
+++ b/src/DataAccessMySqlProvider/project.json
@@ -5,7 +5,7 @@
       "type": "platform"
     },
     "DomainModel": "*",
-    "SapientGuardian.EntityFrameworkCore.MySql": "7.1.0"
+    "SapientGuardian.EntityFrameworkCore.MySql": "7.1.*"
   },
 
   "frameworks": {

--- a/src/DataAccessMySqlProvider/project.json
+++ b/src/DataAccessMySqlProvider/project.json
@@ -1,0 +1,20 @@
+﻿{
+  "dependencies": {
+    "Microsoft.NETCore.App": {
+      "version": "1.0.0",
+      "type": "platform"
+    },
+    "DomainModel": "*",
+    "SapientGuardian.EntityFrameworkCore.MySql": "7.1.0"
+  },
+
+  "frameworks": {
+    "netcoreapp1.0": {
+      "imports": [
+        "dotnet5.6",
+        "dnxcore50",
+        "portable-net45+win8"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #1. This PR adds a MySQL provider, via the [SapientGuardian.EntityFrameworkCore.MySql](https://github.com/SapientGuardian/SapientGuardian.EntityFrameworkCore.MySql) library. It also sets MySQL to be the default provider in Startup.cs, rather than PostgreSQL.
